### PR TITLE
fix clients not closing properly

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,6 +119,7 @@ func (c *Client) offer(ctx context.Context) (abstractSession, error) {
 		if element.Value.IsClosed() {
 			nextElement := element.Next()
 			c.connections.Remove(element)
+			_ = element.Value.Close()
 			element = nextElement
 			continue
 		}


### PR DESCRIPTION
On long running clients, when a connection is closed some functionalities of the mux client remain waiting, for example the smux's send function keeps listening on a channel that never gets closed unless clients's close is called, since isClosed return true and we have disposed of the mux client, the goroutine remains open and stacks up. this PR addresses this issue and closes a mux client properly.