### PR TITLE
fix h2mux RST_STREAM on half-close

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -93,6 +93,10 @@ func (c *clientConn) Upstream() any {
 	return c.Conn
 }
 
+func (c *clientConn) CloseWrite() error {
+	return N.CloseWrite(c.Conn)
+}
+
 var _ N.NetPacketConn = (*clientPacketConn)(nil)
 
 type clientPacketConn struct {

--- a/error.go
+++ b/error.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/hashicorp/yamux"
+	N "github.com/sagernet/sing/common/network"
 )
 
 type wrapStream struct {
@@ -21,6 +22,10 @@ func (w *wrapStream) Write(p []byte) (n int, err error) {
 	n, err = w.Conn.Write(p)
 	err = wrapError(err)
 	return
+}
+
+func (w *wrapStream) CloseWrite() error {
+	return N.CloseWrite(w.Conn)
 }
 
 func (w *wrapStream) Upstream() any {

--- a/h2mux_conn.go
+++ b/h2mux_conn.go
@@ -64,6 +64,10 @@ func (c *httpConn) Close() error {
 	return common.Close(c.reader, c.writer)
 }
 
+func (c *httpConn) CloseWrite() error {
+	return common.Close(c.writer)
+}
+
 func (c *httpConn) LocalAddr() net.Addr {
 	return M.Socksaddr{}
 }


### PR DESCRIPTION
h2mux connections send `RST_STREAM(CANCEL)` instead of `END_STREAM` when the client finishes uploading data.

a repro is at https://gist.github.com/cfal/4eb8b86283ef896046fe00bda50d161f and can be run with `go test -v -run TestSingboxH2MuxLargeTransfer`

before:
```
+0400 2025-12-29 12:07:39 INFO [4108311949 0ms] inbound/vless[vless-in]: [0] inbound connection to sp.mux.sing-box.arpa:444
    singbox_h2mux_test.go:152: SOCKS5 connected to echo server                
    singbox_h2mux_test.go:160: Sending 65536 bytes...                                   
    singbox_h2mux_test.go:167: Closing write side (shutdown)...                                                                                                                        
    singbox_h2mux_test.go:171: Waiting for echo response...
+0400 2025-12-29 12:07:39 DEBUG [3568073759 1ms] connection: connection upload finished
    singbox_h2mux_test.go:188: Received 0 bytes 
```

after:
```
+0400 2025-12-29 12:10:43 DEBUG [2274972886 1ms] connection: connection upload finished
+0400 2025-12-29 12:10:43 DEBUG [272648898 0ms] connection: connection upload finished
    singbox_h2mux_test.go:218: Echo server: received 65536 bytes, echoing back
+0400 2025-12-29 12:10:43 DEBUG [272648898 1ms] connection: connection download finished
+0400 2025-12-29 12:10:43 DEBUG [2274972886 3ms] connection: connection download finished
    singbox_h2mux_test.go:188: Received 65536 bytes
```


